### PR TITLE
Freeze package + version requirements and changed pip install command

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -1,2 +1,4 @@
+#!/bin/sh
+
 sudo apt-get install build-essential python-dev python-pip
-sudo pip install Flask Flask-Session Flask-SQLAlchemy Flask-Mail apscheduler passlib
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+APScheduler==3.0.1
+Flask==0.10.1
+Flask-Mail==0.9.1
+Flask-SQLAlchemy==2.0
+Flask-Session==0.1.1
+SQLAlchemy==0.9.8
+passlib==1.6.2
+six==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ Flask-SQLAlchemy==2.0
 Flask-Session==0.1.1
 SQLAlchemy==0.9.8
 passlib==1.6.2
+py-bcrypt==0.4
 six==1.8.0


### PR DESCRIPTION
Froze versions and formalized package dependencies into `requirements.txt` to help with virtualenv-based development and deployment setups.

For deployment without virtualenv (i.e. single-use VPS setups), running the following is equivalent.

```sh
    sudo ./prepare.sh
```