### PR TITLE
Fix Mailgun from address

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -9,6 +9,11 @@ PERMANENT_SESSION_LIFETIME = 604800 # 7 days in seconds
 HOST = ".ctfd.io"
 UPLOAD_FOLDER = os.path.normpath('static/uploads')
 
+##### EMAIL (Mailgun and non-Mailgun) #####
+
+# The first address will be used as the from address of messages sent from CTFd
+ADMINS = []
+
 ##### EMAIL (if not using Mailgun) #####
 CTF_NAME = ''
 MAIL_SERVER = ''
@@ -17,4 +22,3 @@ MAIL_USE_TLS = False
 MAIL_USE_SSL = False
 MAIL_USERNAME = ''
 MAIL_PASSWORD = ''
-ADMINS = []

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -154,19 +154,19 @@ def set_config(key, value):
 
 
 def mailserver():
-    if get_config('mg_api_key') or (app.config['MAIL_SERVER'] and app.config['MAIL_PORT'] and app.config['ADMINS']):
+    if (get_config('mg_api_key') and app.config['ADMINS']) or (app.config['MAIL_SERVER'] and app.config['MAIL_PORT'] and app.config['ADMINS']):
         return True
     return False
 
 
 def sendmail(addr, text):
-    if get_config('mg_api_key'):
+    if get_config('mg_api_key') and app.config['ADMINS']:
         ctf_name = get_config('ctf_name')
         mg_api_key = get_config('mg_api_key')
         return requests.post(
             "https://api.mailgun.net/v2/mail"+app.config['HOST']+"/messages",
             auth=("api", mg_api_key),
-            data={"from": "{} Admin <noreply@ctfd.io>".format(ctf_name),
+            data={"from": "{} Admin <{}>".format(ctf_name, app.config['ADMINS'][0]),
                   "to": [addr],
                   "subject": "Message from {0}".format(ctf_name),
                   "text": text})


### PR DESCRIPTION
Use the `app.config['ADMINS'][0]` address as the from address in Mailgun messages.

TODO: This email address should probably be configurable in the admin settings.

This is a quick fix to not hardcode the address for emails sent via Mailgun. I also must confess I haven't tested this or configured Mailgun yet.

You might want to just set the admin address to <noreply@ctfd.io> on ctfd.io to get the old behavior back.