### PR TITLE
enable max-attempts per challenge setting

### DIFF
--- a/CTFd/admin.py
+++ b/CTFd/admin.py
@@ -71,6 +71,7 @@ def init_admin(app):
             ctf_name = set_config("ctf_name", request.form.get('ctf_name', None))
             mg_api_key = set_config("mg_api_key", request.form.get('mg_api_key', None))
             do_api_key = set_config("do_api_key", request.form.get('do_api_key', None))
+            max_tries = set_config("max_tries", request.form.get('max_tries', None))
 
             db_start = Config.query.filter_by(key='start').first()
             db_start.value = start
@@ -96,6 +97,11 @@ def init_admin(app):
         if not do_api_key:
             set_config('do_api_key', None)
 
+        max_tries = get_config('max_tries')
+        if not max_tries:
+            set_config('max_tries', 0)
+            max_tries = 0
+
         start = get_config('start')
         if not start:
             set_config('start', None)
@@ -120,6 +126,7 @@ def init_admin(app):
         db.session.close()
 
         return render_template('admin/config.html', ctf_name=ctf_name, start=start, end=end,
+                               max_tries=max_tries,
                                view_challenges_unregistered=view_challenges_unregistered,
                                prevent_registration=prevent_registration, do_api_key=do_api_key, mg_api_key=mg_api_key,
                                prevent_name_change=prevent_name_change)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -62,6 +62,10 @@ def init_views(app):
                 html = request.form['html']
                 page = Pages('index', html)
 
+                #max attempts per challenge
+                max_tries = Config("max_tries",0)
+
+
                 ## Start time
                 start = Config('start', None)
                 end = Config('end', None)
@@ -77,6 +81,7 @@ def init_views(app):
                 db.session.add(ctf_name)
                 db.session.add(admin)
                 db.session.add(page)
+                db.session.add(max_tries)
                 db.session.add(start)
                 db.session.add(end)
                 db.session.add(view_challenges_unregistered)

--- a/static/js/chalboard.js
+++ b/static/js/chalboard.js
@@ -105,6 +105,12 @@ function submitkey(chal, key, nonce) {
           $('#submit-key').css('background-color', '#e18728')
           $('#submit-key').prop('disabled', true)
         }
+        else if (data == 4){ // too many incorrect solves
+          $('#submit-key').text('Too many attempts.')
+          $('#submit-key').css('background-color', 'red')
+          $('#submit-key').prop('disabled', true)
+        }
+        marktoomanyattempts()
         marksolves()
         updatesolves()
         setTimeout(function(){
@@ -122,6 +128,20 @@ function marksolves() {
             id = solves['solves'][i].chalid
             $('#challenges button[value="' + id + '"]').addClass('secondary')
             $('#challenges button[value="' + id + '"]').css('opacity', '0.3')
+        };
+        if (window.location.hash.length > 0){
+          loadchalbyname(window.location.hash.substring(1))
+        }
+    });
+}
+
+function marktoomanyattempts() {
+    $.get('/maxattempts', function (data) {
+        maxattempts = $.parseJSON(JSON.stringify(data));
+        for (var i = maxattempts['maxattempts'].length - 1; i >= 0; i--) {
+            id = maxattempts['maxattempts'][i].chalid
+            $('#challenges button[value="' + id + '"]').addClass('secondary')
+            $('#challenges button[value="' + id + '"]').css('background-color', '#FF9999')
         };
         if (window.location.hash.length > 0){
           loadchalbyname(window.location.hash.substring(1))
@@ -177,6 +197,7 @@ function loadchals() {
             $('#' + challenges['game'][i].category.replace(/ /g,"-")).append($('<button value="' + challenges['game'][i].id + '">' + challenges['game'][i].value + '</button>'));
         };
         updatesolves()
+        marktoomanyattempts()
         marksolves()
 
         $('#challenges button').click(function (e) {

--- a/templates/admin/config.html
+++ b/templates/admin/config.html
@@ -13,6 +13,11 @@
         </div>
 
         <div class="row">
+            <label for="max_tries">Maximum Attempts Per Challenge (0 to disable):</label>
+            <input id='max_tries' name='max_tries' type='text' placeholder="0" {% if max_tries is defined and max_tries != None %}value="{{ max_tries }}"{% endif %}>
+        </div>
+
+        <div class="row">
             <label for="start">Mailgun API Key:</label>
             <input id='mg_api_key' name='mg_api_key' type='text' placeholder="Mailgun API Key" {% if mg_api_key is defined and mg_api_key != None %}value="{{ mg_api_key }}"{% endif %}>
         </div>


### PR DESCRIPTION
This allows admin to set a maximum number of attempts per challenge (0 to disable, which is default).

If max attempts is reached, challenge is marked red and displays appropriate error message when more solutions are submitted.