### PR TITLE
fix least solved challenge statistic

### DIFF
--- a/CTFd/admin.py
+++ b/CTFd/admin.py
@@ -438,7 +438,7 @@ def init_admin(app):
         solve_count = db.session.query(db.func.count(Solves.id)).first()[0]
         challenge_count = db.session.query(db.func.count(Challenges.id)).first()[0]
         most_solved_chal = Solves.query.add_columns(db.func.count(Solves.chalid).label('solves')).group_by(Solves.chalid).order_by('solves DESC').first()
-        least_solved_chal = Solves.query.add_columns(db.func.count(Solves.chalid).label('solves')).group_by(Solves.chalid).order_by('solves ASC').first()
+        least_solved_chal = Challenges.query.add_columns(db.func.count(Solves.chalid).label('solves')).outerjoin(Solves).group_by(Challenges.id).order_by('solves ASC').first()
 
         db.session.close()
 

--- a/templates/admin/statistics.html
+++ b/templates/admin/statistics.html
@@ -13,7 +13,7 @@
         <h3>Most solved: <b>{{ most_solved[0].chal.name }}</b> with {{ most_solved[1] }}</b> solves</h3>
     {% endif %}
     {% if least_solved %}
-    <h3>Least solved: <b>{{ least_solved[0].chal.name }}</b> with {{ least_solved[1] }}</b> solves</h3>
+    <h3>Least solved: <b>{{ least_solved[0].name }}</b> with {{ least_solved[1] }}</b> solves</h3>
     {% endif %}
 </div>
 


### PR DESCRIPTION
If there is a challenge with zero solves, the current statistics does not include it in the "least solved" statistic (because there is no entry for that challenge in the solves table yet).

This fix will show challenges without solves in the least solved statistic.