### PR TITLE
Fixing Dockerfile using old apt cache and start command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:trusty
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get clean && apt-get update && apt-get upgrade -y
 
 RUN apt-get install git gunicorn -y
 RUN git clone https://github.com/isislab/CTFd.git /opt/CTFd && cd /opt/CTFd && ./prepare.sh
 
 WORKDIR /opt/CTFd
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "CTFd:create_app()"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "CTFd:create_app"]
 EXPOSE 8000


### PR DESCRIPTION
Fixing Dockerfile using old apt cache and start command. 

I had an issue with the apt trying to pull different versions and then the container would not start due to the "()" in the start command. 

