### PR TITLE
fix Gunicorn Multi-Processing Problem

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -1,6 +1,6 @@
 import os
 ##### SERVER SETTINGS #####
-SECRET_KEY = os.urandom(64)
+SECRET_KEY = os.environ.get('SECRET_KEY') or os.urandom(64)
 SQLALCHEMY_DATABASE_URI = 'sqlite:///ctfd.db'
 SESSION_TYPE = "filesystem"
 SESSION_FILE_DIR = "/tmp/flask_session"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN git clone https://github.com/isislab/CTFd.git /opt/CTFd && cd /opt/CTFd && .
 RUN pip install -U gunicorn
 
 WORKDIR /opt/CTFd
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "--env", "SECRET_KEY=`head -c 64 /dev/urandom`", "CTFd:create_app()"]
+CMD ["SECRET_KEY=`head -c 24 /dev/urandom` | base64 | tr -d ' \n\t\r'", "gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "CTFd:create_app()"]
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN git clone https://github.com/isislab/CTFd.git /opt/CTFd && cd /opt/CTFd && .
 RUN pip install -U gunicorn
 
 WORKDIR /opt/CTFd
-CMD ["SECRET_KEY=`head -c 24 /dev/urandom` | base64 | tr -d ' \n\t\r'", "gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "CTFd:create_app()"]
+CMD ["SECRET_KEY=`head -c 24 /dev/urandom | base64 | tr -d ' \n\t\r'`", "gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "CTFd:create_app()"]
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:trusty
 RUN apt-get update && apt-get upgrade -y
 
-RUN apt-get install git gunicorn -y
+RUN apt-get install git -y
 RUN git clone https://github.com/isislab/CTFd.git /opt/CTFd && cd /opt/CTFd && ./prepare.sh
+RUN pip install -U gunicorn
 
 WORKDIR /opt/CTFd
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "CTFd:create_app()"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "--env", "SECRET_KEY=`head -c 64 /dev/urandom`", "CTFd:create_app()"]
 EXPOSE 8000


### PR DESCRIPTION
When using Dockerfile to deploy CTFd by gunicorn, I found there is a problem those gunicorn workers can't shared Flask session. That causes users will logout when requesting another page.

To fix this problem, I change the way to get `SECRET_KEY` by `ENVIRONMENT`. If not setting `ENV`, it will use origin way to generate `SECRET_KEY`