### PR TITLE
Docker Compose containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ RUN apk update && apk upgrade
 RUN apk add git gcc musl-dev libffi-dev python python-dev py-pip
 
 RUN mkdir /opt
-RUN git clone https://github.com/isislab/CTFd.git /opt/CTFd && cd /opt/CTFd
+COPY . /opt/CTFd
 WORKDIR /opt/CTFd
 
 RUN pip install -r requirements.txt
+RUN pip install pymysql
 
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-w", "4", "CTFd:create_app()"]
 EXPOSE 8000

--- a/docker-compose-run.sh
+++ b/docker-compose-run.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+sed "s;sqlite:///ctfd.db;mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@db/ctfd;g" CTFd/config.py -i
+
+# wait for mysql to start
+while ! nc db 3306 >/dev/null 2>&1 < /dev/null; do
+    if [ $i -ge 50 ]; then
+      echo "$(date) - db:3306 still not reachable, giving up"
+      exit 1
+    fi
+    echo "$(date) - waiting for db:3306..."
+    sleep 1
+done
+
+gunicorn --bind 0.0.0.0:8000 -w 4 "CTFd:create_app()"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+ctfd:
+  build: .
+  restart: always  
+  environment: 
+    - &MU MYSQL_USER=ctfd
+    - &MP MYSQL_PASSWORD=You_Should_Probably_Override_This
+    - &MD MYSQL_DATABASE=ctfd
+  command: sh docker-compose-run.sh
+  volumes_from:
+    - data:rw
+  links:
+    - db
+
+db:
+  image: mariadb
+  environment:
+    - *MU
+    - *MP
+    - *MD
+    - MYSQL_ROOT_PASSWORD=Unencrypted_Credentials_At_Rest
+  volumes_from:
+    - data:rw
+  
+data:
+  image: mariadb
+  restart: always
+  volumes:
+    - /var/lib/mysql
+    - /opt/CTFd/CTFd/logs
+  command: "tail -f /dev/null"


### PR DESCRIPTION
Containerization of CTFd into gunicorn, Postgres, and data containers for easy backups and upgrades. Can be quickly tested by running:

```
docker-compose build
docker-compose up
```

Data persistence across application source code updates is also tested and working.

`Dockerfile` has been modified to:
* Install `postgresql-dev` and `psycopg2`
* Perform a COPY of the current directory instead of cloning the repo again