### PR TITLE
Don't make current page id a link on Teams page

### DIFF
--- a/CTFd/templates/teams.html
+++ b/CTFd/templates/teams.html
@@ -35,7 +35,11 @@
     <div class="text-center">Page
         <br>
         {% for page in range(1, team_pages + 1) %}
-        <a href="/teams/{{ page }}">{{ page }}</a>
+            {% if curr_page != page %}
+                <a href="/teams/{{ page }}">{{ page }}</a>
+            {% else %}
+                <b>{{page}}</b>
+            {% endif %}
         {% endfor %}
     <a href="">
     </div>

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -136,7 +136,7 @@ def teams(page):
     count = db.session.query(db.func.count(Teams.id)).first()[0]
     print(count)
     pages = int(count / results_per_page) + (count % results_per_page > 0)
-    return render_template('teams.html', teams=teams, team_pages=pages)
+    return render_template('teams.html', teams=teams, team_pages=pages, curr_page=page)
 
 @views.route('/team/<teamid>', methods=['GET', 'POST'])
 def team(teamid):


### PR DESCRIPTION
Go from this:
<img width="104" alt="screen shot 2016-02-05 at 1 02 46 pm" src="https://cloud.githubusercontent.com/assets/505866/12854588/904f8980-cc08-11e5-9f60-77036981536a.png">

To this:
<img width="72" alt="screen shot 2016-02-05 at 1 02 39 pm" src="https://cloud.githubusercontent.com/assets/505866/12854609/981392f6-cc08-11e5-8dd9-0a2ae869fef5.png">
