### PR TITLE
Add Flask-Mail to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask
 Flask-SQLAlchemy
 Flask-Session
+Flask-Mail
 SQLAlchemy
 passlib
 bcrypt


### PR DESCRIPTION
[Flask-Mail](https://pypi.python.org/pypi/Flask-Mail) is imported in utils.py

Otherwise, I get this trace when starting the server.
```
Traceback (most recent call last):
  File "serve.py", line 2, in <module>
    app = create_app()
  File "[..]\CTFd\CTFd\__init__.py", line 23, in create_app
    from CTFd.views import views
  File "[..]\CTFd\CTFd\views.py", line 2, in <module>
    from CTFd.utils import authed, ip2long, long2ip, is_setup, validate_url, get_config, set_config, sha512, get_ip
  File "[..]\CTFd\CTFd\utils.py", line 6, in <module>
    from flask.ext.mail import Message
  File "C:\Python27\lib\site-packages\flask\exthook.py", line 87, in load_module
    raise ImportError('No module named %s' % fullname)
ImportError: No module named flask.ext.mail
```