### PR TITLE
Optionally hide admin accounts from the teams page

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -29,3 +29,4 @@ TRUSTED_PROXIES = [
     '^172\.(1[6-9]|2[0-9]|3[0-1])\.',
     '^192\.168\.'
 ]
+HIDE_ADMIN_TEAMS = False

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -126,9 +126,10 @@ def teams(page):
         teams = Teams.query.filter_by(verified=True).slice(page_start, page_end).all()
     else:
         teams = Teams.query.slice(page_start, page_end).all()
-    for team in teams:
-        if team.admin:
-            teams.remove(team)
+    if get_config('HIDE_ADMIN_TEAMS'):
+        for team in teams:
+            if team.admin:
+                teams.remove(team)
     count = len(teams)
     pages = int(count / results_per_page) + (count % results_per_page > 0)
     return render_template('teams.html', teams=teams, team_pages=pages, curr_page=page)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -126,6 +126,9 @@ def teams(page):
         teams = Teams.query.filter_by(verified=True).slice(page_start, page_end).all()
     else:
         teams = Teams.query.slice(page_start, page_end).all()
+    for team in teams:
+        if team.admin:
+            teams.remove(team)
     count = len(teams)
     pages = int(count / results_per_page) + (count % results_per_page > 0)
     return render_template('teams.html', teams=teams, team_pages=pages, curr_page=page)


### PR DESCRIPTION
Controlled via HIDE_ADMIN_TEAMS in config.py