### PR TITLE
Various small fixes

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, request, redirect, abort, session, jsonify, json as json_mod, url_for
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from logging.handlers import RotatingFileHandler
-from flask.ext.session import Session
+from flask_session import Session
 from sqlalchemy_utils import database_exists, create_database
 import os
 import sqlalchemy

--- a/CTFd/models.py
+++ b/CTFd/models.py
@@ -1,9 +1,9 @@
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.sql import func
 
 from socket import inet_aton, inet_ntoa
-from struct import unpack, pack
+from struct import unpack, pack, error as struct_error
 from passlib.hash import bcrypt_sha256
 
 import datetime
@@ -16,11 +16,15 @@ def sha512(string):
 
 
 def ip2long(ip):
-    return unpack('!I', inet_aton(ip))[0]
+    return unpack('!i', inet_aton(ip))[0]
 
 
 def long2ip(ip_int):
-    return inet_ntoa(pack('!I', ip_int))
+    try:
+        return inet_ntoa(pack('!i', ip_int))
+    except struct_error:
+        # Backwards compatibility with old CTFd databases
+        return inet_ntoa(pack('!I', ip_int))
 
 db = SQLAlchemy()
 
@@ -180,7 +184,7 @@ class Solves(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     chalid = db.Column(db.Integer, db.ForeignKey('challenges.id'))
     teamid = db.Column(db.Integer, db.ForeignKey('teams.id'))
-    ip = db.Column(db.BigInteger)
+    ip = db.Column(db.Integer)
     flag = db.Column(db.Text)
     date = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     team = db.relationship('Teams', foreign_keys="Solves.teamid", lazy='joined')

--- a/CTFd/templates/admin/pages.html
+++ b/CTFd/templates/admin/pages.html
@@ -92,7 +92,7 @@ function load_confirm_modal(route){
 function save_css(){
     var css = editor.getValue();
     var nonce = $('#nonce').val();
-    $.post('/admin/css', {'css':css, 'nonce':nonce}, function(){
+    $.post(script_root + '/admin/css', {'css':css, 'nonce':nonce}, function(){
         console.log('saved');
     });
 }


### PR DESCRIPTION
1.  Fix the deprecation warnings by changing from `flask.ext.$name` to `flask_$name`

 The most recent version of flask has deprecated the redirect namespace, so this is just cleanup.  This should only cause compatibility issues if someone is using an *ancient* version of a flask extension (which they shouldn't be, as you recommend using pip to install things).

2.  Be consistent with import style in admin.py

 One liner change from #125 so that it's consistent with the rest of the file.  Purely cosmetic.

3.  Fix a residual script_root fix

 These keep popping up as my friends do more usability testing.  Again, one liner.

4.  Store IPs in 32 bits again

 This is the only potentially breaking change.  Switching it to a 64 bit integer fixed non-SQLite databases (since the SQLAlchemy integer datatype is the standard SQL integer, which is signed), but is space inefficient and feels quite wrong.  It also was compatible with SQLite since data types and constraints don't actually exist in SQLite.  This change moves it back to 32 bits (which breaks non SQLite, but I believe I'm the only person running this, and I've transitioned my DB).  The difference is the IP address is now stored as a signed 32 bit integer, so it'll fit into the standard SQL integer.

 I've maintained backwards compatibility with old SQLite databases by wrapping the `struct.pack` call in a try-except that will fall back to the old unsigned data type if the result from the database is out of range.  IP addresses that fall within the signed range will be unaffected as well.

I tested everything that could forseeably be affected on my system, and everything works.