### PR TITLE
fix DetachedInstanceError on /admin/statistics

### DIFF
--- a/CTFd/admin.py
+++ b/CTFd/admin.py
@@ -733,7 +733,8 @@ def admin_stats():
     least_solved_chal = Challenges.query.add_columns(solves_cnt) \
         .outerjoin(solves_sub, solves_sub.columns.chalid == Challenges.id) \
         .order_by(solves_cnt.asc()).first()
-
+        
+    db.session.expunge_all()
     db.session.commit()
     db.session.close()
 


### PR DESCRIPTION
see http://stackoverflow.com/questions/15397680/detaching-sqlalchemy-instance-so-no-refresh-happens

maybe expunge every obj is better,but i'm lazy(so use expunge_all()).