### PR TITLE
fix reset_password show twice in reset email

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -67,7 +67,7 @@ def reset_password(data=None):
         text = """
 Did you initiate a password reset? 
 
-{0}/reset_password/{1}
+{0}/{1}
 
 """.format(url_for('auth.reset_password', _external=True), token.encode('base64'))
 


### PR DESCRIPTION
it made something like  http://localhost:4000/reset_password/reset_password/Ilx1MzA1NVx1MzA0Zlx1MzA4OVx1ODM1OCIuQ25zSEN3LlVxRlBxUzB4clR6QzdkREdaR2hBLWIzY1FRcw==

it should be http://localhost:4000/reset_password/Ilx1MzA1NVx1MzA0Zlx1MzA4OVx1ODM1OCIuQ25zSEN3LlVxRlBxUzB4clR6QzdkREdaR2hBLWIzY1FRcw==