### PR TITLE
Fix issue reported in #136

### DIFF
--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -273,7 +273,7 @@ def get_ip():
 
 
 def long2ip(ip_int):
-    return inet_ntoa(pack('!I', ip_int))
+    return inet_ntoa(pack('!I', ip_int&0xFFFFFFFF))
 
 
 def ip2long(ip):


### PR DESCRIPTION
Prevent IP addresses from being treated as a negative number.

Cast to an unsigned INT.