### PR TITLE
Fix MySQL availability tries counter

### DIFF
--- a/docker-compose-run.sh
+++ b/docker-compose-run.sh
@@ -3,13 +3,15 @@
 sed "s;sqlite:///ctfd.db;mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@db/ctfd;g" CTFd/config.py -i
 
 # wait for mysql to start
+cnt=0
 while ! nc db 3306 >/dev/null 2>&1 < /dev/null; do
-    if [ $i -ge 50 ]; then
+    if [ $cnt -ge 50 ]; then
       echo "$(date) - db:3306 still not reachable, giving up"
       exit 1
     fi
     echo "$(date) - waiting for db:3306..."
     sleep 1
+    cnt=`expr $cnt + 1`
 done
 
 gunicorn --bind 0.0.0.0:8000 -w 4 "CTFd:create_app()"


### PR DESCRIPTION
The variable `i` was not declared and never incremented.

The behaviour was the right one (waiting for MySQL to be listening before starting the application) but was displaying errors.