### PR TITLE
Fix deleting wrong keys from admin panel

### DIFF
--- a/CTFd/admin.py
+++ b/CTFd/admin.py
@@ -705,14 +705,17 @@ def delete_solve(teamid, chalid):
     return '1'
 
 
-@admin.route('/admin/wrong_keys/<teamid>/<chalid>/delete', methods=['POST'])
+@admin.route('/admin/wrong_keys/<keyid>/delete', methods=['POST'])
 @admins_only
-def delete_wrong_key(teamid, chalid):
-    wrong_key = WrongKeys.query.filter_by(teamid=teamid, chalid=chalid).first()
+def delete_wrong_key(keyid):
+    wrong_key = WrongKeys.query.filter_by(id=keyid).first()
+    if (wrong_key == None):
+        return '0'
     db.session.delete(wrong_key)
     db.session.commit()
     db.session.close()
     return '1'
+
 
 
 @admin.route('/admin/statistics', methods=['GET'])
@@ -755,7 +758,7 @@ def admin_wrong_key(page='1'):
     page_start = results_per_page * ( page - 1 )
     page_end = results_per_page * ( page - 1 ) + results_per_page
 
-    wrong_keys = WrongKeys.query.add_columns(WrongKeys.chalid, WrongKeys.flag, WrongKeys.teamid, WrongKeys.date,\
+    wrong_keys = WrongKeys.query.add_columns(WrongKeys.id, WrongKeys.chalid, WrongKeys.flag, WrongKeys.teamid, WrongKeys.date,\
                 Challenges.name.label('chal_name'), Teams.name.label('team_name')).\
                 join(Challenges).join(Teams).order_by('team_name ASC').slice(page_start, page_end).all()
 

--- a/CTFd/admin.py
+++ b/CTFd/admin.py
@@ -695,10 +695,10 @@ def create_solve(teamid, chalid):
     db.session.close()
     return '1'
 
-@admin.route('/admin/solves/<teamid>/<chalid>/delete', methods=['POST'])
+@admin.route('/admin/solves/<keyid>/delete', methods=['POST'])
 @admins_only
-def delete_solve(teamid, chalid):
-    solve = Solves.query.filter_by(teamid=teamid, chalid=chalid).first()
+def delete_solve(keyid):
+    solve = Solves.query.filter_by(id=keyid).first_or_404()
     db.session.delete(solve)
     db.session.commit()
     db.session.close()
@@ -774,7 +774,7 @@ def admin_correct_key(page='1'):
     page_start = results_per_page * (page - 1)
     page_end = results_per_page * (page - 1) + results_per_page
 
-    solves = Solves.query.add_columns(Solves.chalid, Solves.teamid, Solves.date, Solves.flag, \
+    solves = Solves.query.add_columns(Solves.id, Solves.chalid, Solves.teamid, Solves.date, Solves.flag, \
                 Challenges.name.label('chal_name'), Teams.name.label('team_name')).\
                 join(Challenges).join(Teams).order_by('team_name ASC').slice(page_start, page_end).all()
 

--- a/CTFd/admin.py
+++ b/CTFd/admin.py
@@ -708,9 +708,7 @@ def delete_solve(teamid, chalid):
 @admin.route('/admin/wrong_keys/<keyid>/delete', methods=['POST'])
 @admins_only
 def delete_wrong_key(keyid):
-    wrong_key = WrongKeys.query.filter_by(id=keyid).first()
-    if (wrong_key == None):
-        return '0'
+    wrong_key = WrongKeys.query.filter_by(id=keyid).first_or_404()
     db.session.delete(wrong_key)
     db.session.commit()
     db.session.close()

--- a/CTFd/templates/original/admin/correct_keys.html
+++ b/CTFd/templates/original/admin/correct_keys.html
@@ -52,7 +52,7 @@
                 <td class="text-center team" id="{{ solve.teamid }}"><a href="{{ request.script_root }}/admin/team/{{ solve.teamid }}">{{ solve.team_name }}</a>
                 <td class="text-center chal" id="{{ solve.chalid }}">{{ solve.chal_name }}</td>
                 <td class="text-center solve-time"><script>document.write( moment({{ solve.date|unix_time_millis }}).local().format('MMMM Do, h:mm:ss A'))</script></td>
-                <td class="text-center">{{ solve.flag }}</td>
+                <td class="text-center flag" id="{{ solve.id }}">{{ solve.flag }}</td>
                 <td class="text-center"><i class="fa fa-times"></i></td>
             </tr>
             {% endfor %}
@@ -78,7 +78,6 @@
 
 {% block scripts %}
     <script src="{{ request.script_root }}/static/{{ ctf_theme() }}/js/utils.js"></script>
-    <script src="{{ request.script_root }}/static/{{ ctf_theme() }}/admin/js/team.js"></script>
     <script>
     $('#delete-solve').click(function(e){
         e.preventDefault();
@@ -91,11 +90,11 @@
         })
     });
 
-    function load_confirm_modal(team, chal, team_name, chal_name){
+    function load_confirm_modal(key_id, team_name, chal_name){
         var modal = $('#confirm')
         modal.find('#confirm-team-name').text(team_name)
         modal.find('#confirm-chal-name').text(chal_name)
-        $('#confirm form').attr('action', '{{ request.script_root }}/admin/solves/'+team+'/'+chal+'/delete');
+        $('#confirm form').attr('action', '{{ request.script_root }}/admin/solves/'+key_id+'/delete');
         $('#confirm').modal('show');
     }
 
@@ -105,7 +104,8 @@
         var chal_name = elem.find('.chal').text().trim();
         var team = elem.find('.team').attr('id');
         var team_name = elem.find('.team').text().trim();
-        load_confirm_modal(team, chal, team_name, chal_name)
+        var key_id = elem.find('.flag').attr('id');
+        load_confirm_modal(key_id, team_name, chal_name)
     });
     </script>
 {% endblock %}

--- a/CTFd/templates/original/admin/team.html
+++ b/CTFd/templates/original/admin/team.html
@@ -161,7 +161,7 @@
         {% for solve in solves %}
             <tr class="chal-solve">
                 <td class="text-center chal" id="{{ solve.chalid }}">{{ solve.chal.name }}</td>
-                <td class="text-center">{{ solve.flag }}</td>
+                <td class="text-center flag" id="{{ solve.id }}">{{ solve.flag }}</td>
                 <td class="text-center">{{ solve.chal.category }}</td>
                 <td class="text-center">{{ solve.chal.value }}</td>
                 <td class="text-center solve-time"><script>document.write( moment({{ solve.date|unix_time_millis }}).local().format('MMMM Do, h:mm:ss A'))</script></td>
@@ -208,7 +208,7 @@
         {% for wrong_key in wrong_keys %}
             <tr class="chal-wrong">
                 <td class="text-center chal" id="{{ wrong_key.chalid }}">{{ wrong_key.chal.name }}</td>
-                <td class="text-center">{{ wrong_key.flag }}</td>
+                <td class="text-center flag" id="{{ wrong_key.id }}">{{ wrong_key.flag }}</td>
                 <td class="text-center solve-time"><script>document.write( moment({{ wrong_key.date|unix_time_millis }}).local().format('MMMM Do, h:mm:ss A'))</script></td>
                 <td class="text-center"><i class="fa fa-times"></i></td>
             </tr>
@@ -250,10 +250,9 @@
         $('.fa-times').click(function () {
             var elem = $(this).parent().parent();
             var type = elem.attr('class');
-            var chal = elem.find('.chal').attr('id');
             var chal_name = elem.find('.chal').text().trim();
-            var team = window.location.pathname.split('/').pop();
             var team_name = $("#team-id").text();
+            var key_id = elem.find('.flag').attr('id');
 
             if (type == 'chal-solve'){
                 var title = 'Delete Solve';
@@ -270,7 +269,7 @@
                 description.find('#confirm-chal-name').text(chal_name);
                 description = description.html()
 
-                var action = '{{ request.script_root }}/admin/solves/' + team + '/' + chal + '/delete';
+                var action = '{{ request.script_root }}/admin/solves/' + key_id + '/delete';
             } else if (type == 'chal-wrong') {
                 var title = 'Delete Wrong Key';
                 var description = "<span>Are you sure you want to delete " +
@@ -285,7 +284,7 @@
                 description.find('#confirm-chal-name').text(chal_name);
                 description = description.html()
 
-                var action = '{{ request.script_root }}/admin/wrong_keys/' + team + '/' + chal + '/delete';
+                var action = '{{ request.script_root }}/admin/wrong_keys/' + key_id + '/delete';
             } else if (type == 'award-row') {
                 var title = 'Delete Award';
                 var description = "<span>Are you sure you want to delete the " +

--- a/CTFd/templates/original/admin/wrong_keys.html
+++ b/CTFd/templates/original/admin/wrong_keys.html
@@ -85,7 +85,6 @@
 
 {% block scripts %}
     <script src="{{ request.script_root }}/static/{{ ctf_theme() }}/js/utils.js"></script>
-    <script src="{{ request.script_root }}/static/{{ ctf_theme() }}/admin/js/team.js"></script>
     <script>
         $('#delete-solve').click(function (e) {
             e.preventDefault();

--- a/CTFd/templates/original/admin/wrong_keys.html
+++ b/CTFd/templates/original/admin/wrong_keys.html
@@ -56,10 +56,10 @@
         <tbody>
             {% for wrong_key in wrong_keys %}
             <tr>
-                <td class="text-center team" id="{{ wrong_key.team }}"><a href="{{ request.script_root }}/admin/team/{{ wrong_key.team }}">{{ wrong_key.team_name }}</a>
+                <td class="text-center team" id="{{ wrong_key.teamid }}"><a href="{{ request.script_root }}/admin/team/{{ wrong_key.team }}">{{ wrong_key.team_name }}</a>
                 <td class="text-center chal" id="{{ wrong_key.chalid }}">{{ wrong_key.chal_name }}</td>
                 <td class="text-center solve-time"><script>document.write( moment({{ wrong_key.date|unix_time_millis }}).local().format('MMMM Do, h:mm:ss A'))</script></td>
-                <td class="text-center">{{ wrong_key.flag }}</td>
+                <td class="text-center flag" id="{{ wrong_key.id }}">{{ wrong_key.flag }}</td>
                 <td class="text-center"><i class="fa fa-times"></i></td>
             </tr>
             {% endfor %}
@@ -98,11 +98,11 @@
             })
         });
 
-        function load_confirm_modal(team, chal, team_name, chal_name) {
+        function load_confirm_modal(keyId, team_name, chal_name) {
             var modal = $('#confirm')
             modal.find('#confirm-team-name').text(team_name);
             modal.find('#confirm-chal-name').text(chal_name);
-            $('#confirm form').attr('action', '{{ request.script_root }}/admin/wrong_keys/' + team + '/' + chal + '/delete');
+            $('#confirm form').attr('action', '{{ request.script_root }}/admin/wrong_keys/' + keyId + '/delete');
             $('#confirm').modal('show');
         }
 
@@ -112,7 +112,8 @@
             var chal_name = elem.find('.chal').text().trim();
             var team = elem.find('.team').attr('id');
             var team_name = elem.find('.team').text().trim();
-            load_confirm_modal(team, chal, team_name, chal_name);
+            var keyId = elem.find('.flag').attr('id');
+            load_confirm_modal(keyId, team_name, chal_name);
         });
     </script>
 {% endblock %}

--- a/CTFd/templates/original/admin/wrong_keys.html
+++ b/CTFd/templates/original/admin/wrong_keys.html
@@ -98,11 +98,11 @@
             })
         });
 
-        function load_confirm_modal(keyId, team_name, chal_name) {
+        function load_confirm_modal(key_id, team_name, chal_name) {
             var modal = $('#confirm')
             modal.find('#confirm-team-name').text(team_name);
             modal.find('#confirm-chal-name').text(chal_name);
-            $('#confirm form').attr('action', '{{ request.script_root }}/admin/wrong_keys/' + keyId + '/delete');
+            $('#confirm form').attr('action', '{{ request.script_root }}/admin/wrong_keys/' + key_id + '/delete');
             $('#confirm').modal('show');
         }
 
@@ -112,8 +112,8 @@
             var chal_name = elem.find('.chal').text().trim();
             var team = elem.find('.team').attr('id');
             var team_name = elem.find('.team').text().trim();
-            var keyId = elem.find('.flag').attr('id');
-            load_confirm_modal(keyId, team_name, chal_name);
+            var key_id = elem.find('.flag').attr('id');
+            load_confirm_modal(key_id, team_name, chal_name);
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
- Fixed wrong_keys.html template using WrongKeys.team instead of
  WrongKeys.teamid
- Added the id of the wrong key to the wrong_keys.html template entries
- Changed /admin/wrong_keys to only take the key id instead of team and
  challenge id, to allow deleting the intended key when a team has more
  than one wrong key for a challenge. (Previously it would delete only
  the first wrong key entry for that challenge)