### PR TITLE
Fixed hard coded upload directory

### DIFF
--- a/CTFd/admin.py
+++ b/CTFd/admin.py
@@ -379,8 +379,9 @@ def admin_files(chalid):
     if request.method == 'POST':
         if request.form['method'] == "delete":
             f = Files.query.filter_by(id=request.form['file']).first_or_404()
-            if os.path.exists(os.path.join(app.root_path, 'uploads', f.location)): # Some kind of os.path.isfile issue on Windows...
-                os.unlink(os.path.join(app.root_path, 'uploads', f.location))
+            upload_folder = os.path.join(app.root_path, app.config['UPLOAD_FOLDER'])
+            if os.path.exists(os.path.join(upload_folder, f.location)): # Some kind of os.path.isfile issue on Windows...
+                os.unlink(os.path.join(upload_folder, f.location))
             db.session.delete(f)
             db.session.commit()
             db.session.close()
@@ -818,7 +819,8 @@ def admin_delete_chal():
     files = Files.query.filter_by(chal=challenge.id).all()
     Files.query.filter_by(chal=challenge.id).delete()
     for file in files:
-        folder = os.path.dirname(os.path.join(os.path.normpath(app.root_path), 'uploads', file.location))
+        upload_folder = app.config['UPLOAD_FOLDER']
+        folder = os.path.dirname(os.path.join(os.path.normpath(app.root_path), upload_folder, file.location))
         rmdir(folder)
     Tags.query.filter_by(chal=challenge.id).delete()
     Challenges.query.filter_by(id=challenge.id).delete()

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -82,10 +82,10 @@ class Config(object):
 
     '''
     UPLOAD_FOLDER is the location where files are uploaded.
-    The default destination is the CTFd/static/uploads folder. If you need Amazon S3 files
+    The default destination is the CTFd/uploads folder. If you need Amazon S3 files
     you can use the CTFd S3 plugin: https://github.com/ColdHeat/CTFd-S3-plugin
     '''
-    UPLOAD_FOLDER = os.path.normpath('static/uploads')
+    UPLOAD_FOLDER = os.path.normpath('uploads')
 
 
     '''

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -308,10 +308,11 @@ def upload_file(file, chalid):
 
     md5hash = hashlib.md5(os.urandom(64)).hexdigest()
 
-    if not os.path.exists(os.path.join(os.path.normpath(app.root_path), 'uploads', md5hash)):
-        os.makedirs(os.path.join(os.path.normpath(app.root_path), 'uploads', md5hash))
+    upload_folder = os.path.join(os.path.normpath(app.root_path), app.config['UPLOAD_FOLDER'])
+    if not os.path.exists(os.path.join(upload_folder, md5hash)):
+        os.makedirs(os.path.join(upload_folder, md5hash))
 
-    file.save(os.path.join(os.path.normpath(app.root_path), 'uploads', md5hash, filename))
+    file.save(os.path.join(upload_folder, md5hash, filename))
     db_f = Files(chalid, (md5hash + '/' + filename))
     db.session.add(db_f)
     db.session.commit()

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -229,4 +229,5 @@ def file_handler(path):
                     pass
                 else:
                     abort(403)
-    return send_file(os.path.join(app.root_path, 'uploads', f.location))
+    upload_folder = os.path.join(app.root_path, app.config['UPLOAD_FOLDER'])
+    return send_file(os.path.join(upload_folder, f.location))


### PR DESCRIPTION
With this commit, the upload folder configured in config.py will be used as one might expect

Hard coded upload directory name was preventing work in importing/exporting challenge specs in a smooth manner.