### PR TITLE
Fix display of team websites with https:// prefixes

### DIFF
--- a/CTFd/templates/admin/teams.html
+++ b/CTFd/templates/admin/teams.html
@@ -128,7 +128,7 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
                 <td class="team-name"><a href="{{ request.script_root }}/admin/team/{{ team.id }}">{{ team.name | truncate(32) }}</a>
                 </td>
                 <td class="team-email">{{ team.email | truncate(32) }}</td>
-                <td class="team-website">{% if team.website and team.website.startswith('http') %}<a href="{{ team.website }}">{{ team.website | truncate(32) }}</a>{% endif %}
+                <td class="team-website">{% if team.website and (team.website.startswith('http://') or team.website.startswith('https://')) %}<a href="{{ team.website }}">{{ team.website | truncate(32) }}</a>{% endif %}
                 </td>
                 <td class="team-affiliation"><span>{% if team.affiliation %}{{ team.affiliation | truncate(20) }}{% endif %}</span>
                 </td>

--- a/CTFd/templates/original/teams.html
+++ b/CTFd/templates/original/teams.html
@@ -23,7 +23,7 @@
         {% for team in teams %}
             <tr>
                 <td><a href="{{ request.script_root }}/team/{{ team.id }}">{{ team.name }}</a></td>
-                <td>{% if team.website and team.website.startswith('http://') %}<a href="{{ team.website }}">{{ team.website }}</a>{% endif %}</td>
+                <td>{% if team.website and (team.website.startswith('http://') or team.website.startswith('https://')) %}<a href="{{ team.website }}">{{ team.website }}</a>{% endif %}</td>
                 <td><span>{% if team.affiliation %}{{ team.affiliation }}{% endif %}</span></td>
                 <td class="hidden-xs"><span>{% if team.country %}{{ team.country }}{% endif %}</span></td>
             </tr>


### PR DESCRIPTION
Team websites starting with https:// are allowed by the URL verification function but are not displayed by the teams templates. This fixes that so https:// team websites are visible on the team list pages.