### PR TITLE
Pin Ubuntu version and follow Dockerfile best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM ubuntu:latest
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install build-essential python-dev python-pip libffi-dev mysql-client -y
+FROM ubuntu:16.04
+
+RUN apt update && \
+    apt install -y \
+        build-essential \
+        libffi-dev \
+        mysql-client \
+        python-dev \
+        python-pip && \
+    rm -rf /var/lib/apt/lists/*
 
 VOLUME ["/opt/CTFd"]
 


### PR DESCRIPTION
Docker provides some useful resources for Ubuntu as a base image
and installing software via apt-get:

https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#apt-get

It's also useful to pin the Ubuntu version to 16.04 so we have a good
idea of what OS we're using in the image. To that end, I think we can
also avoid performing an upgrade so we can even further control which
versions of software we're using. If we do an upgrade then you'll have
different versions of software depending on when you build the image.