### PR TITLE
Fix undefined variable

### DIFF
--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -591,7 +591,7 @@ def container_ports(name, verbose=False):
             ports = info[0]['Config']['ExposedPorts'].keys()
             if not ports:
                 return []
-            ports = [int(re.sub('[A-Za-z/]+', '', port)) for port in ports_asked]
+            ports = [int(re.sub('[A-Za-z/]+', '', port)) for port in ports]
             return ports
     except subprocess.CalledProcessError:
         return []


### PR DESCRIPTION
`ports_asked` was undefined, this got caught by my auto-linter :)

What do you think about fixing PEP8 errors and adding `pep8` into the build process? Something like:

```
$ pep8 --ignore E501 CTFd/
CTFd/__init__.py:15:1: E302 expected 2 blank lines, found 1
CTFd/__init__.py:44:35: E262 inline comment should start with '# '
CTFd/__init__.py:58:24: E261 at least two spaces before inline comment
CTFd/__init__.py:58:25: E262 inline comment should start with '# '
CTFd/__init__.py:61:78: E261 at least two spaces before inline comment
CTFd/__init__.py:61:79: E262 inline comment should start with '# '
CTFd/auth.py:22:41: E261 at least two spaces before inline comment
CTFd/auth.py:39:45: E261 at least two spaces before inline comment
...
```

It's a cheap way to catch bugs like this, and also to keep code consistent. Most editors have a plugin that will show you lint errors inline too, which makes it easy to get quick lint feedback. E.g. with vim I use [syntastic](https://github.com/vim-syntastic/syntastic).